### PR TITLE
Fixed a bug with the TestUtil.createTestDeck() by using an excluding range

### DIFF
--- a/src/test/groovy/nl/quintor/solitaire/TestUtil.groovy
+++ b/src/test/groovy/nl/quintor/solitaire/TestUtil.groovy
@@ -17,7 +17,7 @@ class TestUtil {
         result.invisibleCards = nrOfInvisible
         def fullCards = Deck.createDefaultDeck()
         if (nrOfCards > 0){
-            (0..nrOfCards).each {
+            (0..<nrOfCards).each {
                 result.add(fullCards.remove(it))
             }
         }


### PR DESCRIPTION
Old situation caused nrCards of n>0 being passed to generate a deck with n+1 cards